### PR TITLE
feat: add Dockerfile and readme instructions for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM clojure:openjdk-11-lein
 
-ENV HTTP_PORT "1337"
+ENV HTTP_PORT "13337"
 
 ADD . .
 
 RUN lein install
+
+EXPOSE 13337
 
 ENTRYPOINT ["lein", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ ENV HTTP_PORT "13337"
 
 ADD . .
 
-RUN lein install
+RUN mkdir -p ~/athens/db/athens-sync && \
+  lein install
 
 EXPOSE 13337
+
+VOLUME ["/root/athens/db/athens-sync"]
 
 ENTRYPOINT ["lein", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ EXPOSE 13337
 
 VOLUME ["/root/athens/db/athens-sync"]
 
-ENTRYPOINT ["lein", "run"]
+ENTRYPOINT ["java", "-jar", "./target/uberjar/athens-backend.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV HTTP_PORT "13337"
 ADD . .
 
 RUN mkdir -p ~/athens/db/athens-sync && \
-  lein install
+  lein uberjar
 
 EXPOSE 13337
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM clojure:openjdk-11-lein
+
+ENV HTTP_PORT "1337"
+
+ADD . .
+
+RUN lein install
+
+ENTRYPOINT ["lein", "run"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Default value is: 1337
 Provide your own port number via command line option `-p/--http-port`
 or environment variable `HTTP_PORT`.
 
+## Deployment
 
+### Heroku
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
@@ -24,3 +26,10 @@ Steps to test out **Real time collaboration**
 #### Important Note
 
 This is only a **test deployment** and **all changes will be lost** once heroku dyno reloads(which happens once a day atleast)
+
+### Docker
+
+1. Clone the repo
+2. `docker build -t athens-backend .`
+3. `docker run -it -p 1337:1337 athens-backend`
+

--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ This is only a **test deployment** and **all changes will be lost** once heroku 
 
 1. Clone the repo
 2. `docker build -t athens-backend .`
-3. `docker run -it -p 1337:1337 athens-backend`
+3. `docker run -it -p 13337:13337 athens-backend`
 
+Note that the Docker container exposes "13337" by default instead of "1337" so that this container can run in less privileged environments which may not allow low-ports. It can still be overridden by the HTTP_PORT variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.3'
+services:
+    athens-backend:
+        ports:
+            - '13337:13337'
+        volumes:
+            - '/root/athens/db/athens-sync:/tmp/athens'
+        image: 'erulabs/athens-backend:latest'


### PR DESCRIPTION
Hello!

  Athens looks great, thanks for all your hard work!

  I typically run things inside a Kubernetes cluster, and as-such, I noticed the lack of a Docker image for athens-backend. I've added one in this PR and also pushed a built copy to `erulabs/athens-backend` (https://hub.docker.com/r/erulabs/athens-backend).

  I've also created a Kubernetes YAML template for Athens-backend, which is available here https://kubesail.com/template/erulabs/athens-backend

  I've seen a few notes like:

>  This is only a test deployment and all changes will be lost once heroku dyno reloads(which happens once a day atleast)

  What's the correct way to persist changes? By reading the code, it appears that `athens-sync` uses a path like "~/athens/db/athens-sync". If that's correct, I'll setup the Kubernetes example and docker example to include that as a "Volume", so changes won't be lost on restarts of the service. **EDIT**: I've gone ahead and added a `VOLUME` for `/root/athens/db/athens-sync` in the Dockerfile as well as a `PersistentVolumeClaim` in the [YAML](https://kubesail.com/template/erulabs/athens-backend).

`<pitch>`A small note: I'm the founder of KubeSail.com - we essentially make it easy for "self-hosted" products like Athens to easily build a hosted version for their customers - think Shopify but for Docker containers - and to easily handle on-prem and enterprise installations. I see ya'll are working on a hosted version of Athens - we can get this going in a matter of hours, instead of months. Feel free to reach out!`</pitch>`

Hopefully this helps people run athens-backend a bit easier! No Clojure/Lein install required 💃 