### PR TITLE
Fix: docker port publish flag in Readme and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ This is only a **test deployment** and **all changes will be lost** once heroku 
 
 1. Clone the repo
 2. `docker build -t athens-backend .`
-3. `docker run -it -p 13337:13337 athens-backend`
+3. `docker run -it -p 13337:1337 athens-backend`
 
 Note that the Docker container exposes "13337" by default instead of "1337" so that this container can run in less privileged environments which may not allow low-ports. It can still be overridden by the HTTP_PORT variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
     athens-backend:
         ports:
-            - '13337:13337'
+            - '13337:1337'
         volumes:
             - '/root/athens/db/athens-sync:/tmp/athens'
         image: 'erulabs/athens-backend:latest'


### PR DESCRIPTION
The instance of athens-backend running in the Docker container does not override the port it binds to, so it defaults to 1337. See this output from docker run:

`2021-05-02T22:58:33.255Z c1905a9d99d2 INFO [athens-sync.core:62] - :parsed-args {:options {:http-port 1337}, :arguments [], :summary "  -p, --http-port HTTP_PORT  1337  HTTP Port number", :errors nil}`

Running `docker run` with `-p 13337:13337` is incorrect. It should be `-p 13337:1337`, bind host port 13337 to container port 1337.

This PR updates the README to resolve the confusion and updates the docker-compose.yml so that `docker-compose up -d` behaves as intended.