### PR TITLE
Fix: Use correct data path in docker-compose example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
         ports:
             - '13337:1337'
         volumes:
-            - '/root/athens/db/athens-backend:/tmp/athens'
+            - '/root/athens/db/athens-backend:/tmp/~/athens'
         image: 'erulabs/athens-backend:latest'


### PR DESCRIPTION
This is connected to #4

I noticed that my data folder on the host was empty after starting up the container.
After changing the path to this one the data is correctly persisted on the host.